### PR TITLE
feat: add ss-autoresearch, ss-ml-paper-writing, and ss-mcp-builder skills

### DIFF
--- a/skills/ss-autoresearch/SKILL.md
+++ b/skills/ss-autoresearch/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: ss-autoresearch
+description: >-
+  Orchestrates end-to-end autonomous AI research projects using a two-loop
+  architecture. The inner loop runs rapid experiment iterations; the outer loop
+  synthesizes results, identifies patterns, and steers research direction.
+  Produces research presentations and papers. Use when asked to run autonomous
+  research, design and execute ML experiments end-to-end, or generate a research
+  report from a hypothesis.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Agent
+  - WebFetch
+  - WebSearch
+metadata:
+  source: K-Dense-AI/claude-scientific-skills
+  depends-on: ss-ml-paper-writing ss-arxiv-database
+---
+
+# AutoResearch — Autonomous AI Research Loop
+
+Orchestrates end-to-end AI research using a two-loop architecture. The outer
+loop steers direction; the inner loop executes experiments rapidly. Outputs
+include structured findings, analysis notebooks, and draft papers.
+
+---
+
+## Architecture
+
+```
+Outer Loop (strategic)
+  └─ sets hypothesis, reads inner-loop summaries, adjusts direction
+     Inner Loop (tactical)
+       └─ runs experiment → collects metrics → writes summary → repeats
+```
+
+---
+
+## Phase 0 — Frame the Research Question
+
+1. Clarify the research objective with the user (one clear hypothesis).
+2. Identify baselines, datasets, and evaluation metrics.
+3. Create `research/plan.md` with: hypothesis, success criteria, compute budget.
+4. Search related work: use `ss-arxiv-database` or WebSearch for prior art.
+
+---
+
+## Phase 1 — Inner Loop: Rapid Experimentation
+
+For each experiment iteration:
+
+### 1.1 Design the experiment
+- Pick one variable to change (ablation-friendly).
+- Document the change in `research/experiments/<run_id>/config.md`.
+
+### 1.2 Execute
+```bash
+# Run experiment and capture output
+python experiments/run.py --config research/experiments/<run_id>/config.md \
+  2>&1 | tee research/experiments/<run_id>/log.txt
+```
+
+### 1.3 Record metrics
+Write results to `research/experiments/<run_id>/metrics.json`:
+```json
+{
+  "run_id": "<run_id>",
+  "hypothesis": "...",
+  "metric_name": 0.0,
+  "wall_time_s": 0
+}
+```
+
+### 1.4 Write summary
+Append one-paragraph summary to `research/findings.md`:
+- What changed, what the metric showed, what it implies.
+
+### 1.5 Decide: continue or surface to outer loop
+- **Continue** if the trend is clear and budget remains.
+- **Surface** if results are surprising, budget is 80% spent, or a pattern emerges.
+
+---
+
+## Phase 2 — Outer Loop: Synthesis and Steering
+
+Triggered after each inner-loop surface event.
+
+1. Read all `research/experiments/*/metrics.json` and `research/findings.md`.
+2. Identify the top-performing configuration and the clearest pattern.
+3. Generate a ranked hypothesis list for the next inner-loop batch.
+4. Update `research/plan.md` with revised direction.
+5. If the research objective is met → proceed to Phase 3.
+
+---
+
+## Phase 3 — Output Generation
+
+### Research Report
+Create `research/report.md` containing:
+- Abstract (3–5 sentences)
+- Introduction with motivation
+- Methods: what was varied, how experiments were run
+- Results: tables of key metrics, winning configuration
+- Analysis: what patterns emerged, why
+- Conclusion and future work
+
+### Presentation (optional)
+If the user wants slides, invoke `ss-make-slides` with `research/report.md` as input.
+
+### Paper (optional)
+If the user wants a publication-ready draft, invoke `ss-ml-paper-writing` with
+the report and experiment data.
+
+---
+
+## Guardrails
+
+- **Never delete** experiment logs — always append.
+- **Always validate** that code runs before marking an experiment complete.
+- **Cap inner-loop iterations** at the compute budget in `research/plan.md`.
+- **Reproducibility**: log random seeds, library versions, hardware specs in each config.
+
+---
+
+## Output Files
+
+| File | Purpose |
+|------|---------|
+| `research/plan.md` | Hypothesis, success criteria, budget |
+| `research/findings.md` | Running narrative across all experiments |
+| `research/experiments/<id>/config.md` | Per-run configuration |
+| `research/experiments/<id>/metrics.json` | Per-run metrics |
+| `research/report.md` | Final synthesized report |

--- a/skills/ss-mcp-builder/SKILL.md
+++ b/skills/ss-mcp-builder/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: ss-mcp-builder
+description: >-
+  Guide for creating high-quality MCP (Model Context Protocol) servers that
+  enable LLMs to interact with external services through well-designed tools.
+  Use when building MCP servers to integrate external APIs or services, whether
+  in Python (FastMCP) or Node/TypeScript (MCP SDK).
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - WebFetch
+  - WebSearch
+metadata:
+  source: anthropics/skills
+---
+
+# MCP Server Development Guide
+
+Create MCP (Model Context Protocol) servers that enable LLMs to interact with
+external services through well-designed tools. Quality is measured by how well
+the server enables LLMs to accomplish real-world tasks.
+
+---
+
+## Phase 1 — Research and Planning
+
+### 1.1 Understand the API
+- Review the target service's API docs: endpoints, auth, rate limits, data models.
+- Fetch the MCP spec overview: `https://modelcontextprotocol.io/specification/draft.md`
+- Fetch the SDK README:
+  - TypeScript: `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+  - Python: `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
+
+### 1.2 Choose your stack
+
+**Recommended: TypeScript + Streamable HTTP**
+- TypeScript SDK has the best compatibility across MCP clients.
+- Streamable HTTP for remote servers (stateless, scales easily).
+- stdio for local/CLI servers.
+
+**Python (FastMCP)** is a good alternative for data-heavy or scientific integrations.
+
+### 1.3 Plan your tools
+
+Prioritize **comprehensive API coverage** over workflow shortcuts:
+- List key endpoints to expose as tools.
+- Use consistent naming: `<service>_<action>` (e.g., `github_create_issue`).
+- Plan pagination for list endpoints.
+- Plan error messages that guide the agent toward a fix.
+
+---
+
+## Phase 2 — Implementation
+
+### 2.1 TypeScript project setup
+
+```bash
+mkdir my-mcp-server && cd my-mcp-server
+npm init -y
+npm install @modelcontextprotocol/sdk zod
+npm install -D typescript @types/node
+npx tsc --init
+```
+
+`package.json` scripts:
+```json
+{
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  }
+}
+```
+
+### 2.2 Python (FastMCP) setup
+
+```bash
+pip install mcp fastmcp httpx
+```
+
+### 2.3 Core server pattern (TypeScript)
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({ name: "my-server", version: "1.0.0" });
+
+server.registerTool(
+  "service_list_items",
+  {
+    description: "List items from the service with optional filtering.",
+    inputSchema: {
+      query: z.string().optional().describe("Search query"),
+      limit: z.number().min(1).max(100).default(20).describe("Max results"),
+    },
+    annotations: { readOnlyHint: true },
+  },
+  async ({ query, limit }) => {
+    // Call the external API
+    const data = await fetchFromApi(query, limit);
+    return {
+      content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+    };
+  }
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+### 2.4 Core server pattern (Python / FastMCP)
+
+```python
+from mcp.server.fastmcp import FastMCP
+import httpx
+
+mcp = FastMCP("my-server")
+
+@mcp.tool()
+async def service_list_items(query: str = "", limit: int = 20) -> str:
+    """List items from the service with optional filtering."""
+    async with httpx.AsyncClient() as client:
+        r = await client.get(BASE_URL, params={"q": query, "limit": limit})
+        r.raise_for_status()
+        return r.text
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+### 2.5 Tool design checklist
+
+For each tool:
+- [ ] Clear, action-oriented name with service prefix
+- [ ] Concise description (one sentence + parameter notes)
+- [ ] Input schema with constraints and descriptions
+- [ ] Proper annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`)
+- [ ] Actionable error messages ("Not found. Try listing first with `service_list_items`.")
+- [ ] Pagination for list operations (`cursor`/`page` parameter)
+- [ ] Return structured JSON when output schema is defined
+
+---
+
+## Phase 3 — Build and Test
+
+### TypeScript
+```bash
+npm run build
+npx @modelcontextprotocol/inspector dist/index.js
+```
+
+### Python
+```bash
+python -m py_compile server.py
+fastmcp dev server.py
+```
+
+### Quality review
+- No duplicated code (DRY).
+- Consistent error handling across all tools.
+- Full type coverage (no `any` in TypeScript, no untyped params in Python).
+- Tool descriptions are discoverable — would a model know when to use each one?
+
+---
+
+## Phase 4 — Evaluations
+
+Create 10 evaluation Q&A pairs to verify the server enables real tasks.
+
+**Question criteria:**
+- Independent (not dependent on other questions)
+- Read-only (non-destructive operations only)
+- Complex (requires ≥ 3 tool calls)
+- Realistic (a real user would ask this)
+- Verifiable (single, stable, string-comparable answer)
+
+**Output format** (`evals/eval.xml`):
+```xml
+<evaluation>
+  <qa_pair>
+    <question>How many open issues labeled "bug" exist in the repository?</question>
+    <answer>42</answer>
+  </qa_pair>
+</evaluation>
+```
+
+---
+
+## Transport Reference
+
+| Transport | When to use |
+|-----------|------------|
+| stdio | Local/CLI server, single user |
+| Streamable HTTP (stateless) | Remote/cloud server, multiple users |
+| SSE (legacy) | Only if the client requires it |
+
+---
+
+## Error Message Guidelines
+
+Bad: `"Error: 404"`
+Good: `"Item 'foo' not found. Use service_list_items to see available items."`
+
+Always include:
+1. What failed.
+2. Why it failed (if known).
+3. What the agent should try next.

--- a/skills/ss-ml-paper-writing/SKILL.md
+++ b/skills/ss-ml-paper-writing/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: ss-ml-paper-writing
+description: >-
+  Write publication-ready ML/AI/Systems papers for NeurIPS, ICML, ICLR, ACL,
+  AAAI, COLM, OSDI, NSDI, ASPLOS, SOSP. Use when drafting papers from research
+  repos, structuring arguments, verifying citations, or preparing camera-ready
+  submissions. Includes LaTeX templates and reviewer guidelines.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - WebFetch
+  - WebSearch
+  - Agent
+metadata:
+  source: K-Dense-AI/claude-scientific-skills
+  depends-on: ss-arxiv-database ss-citation-cff
+---
+
+# ML Paper Writing
+
+Produce publication-ready papers for top ML, AI, and systems venues. Follows
+reviewer expectations for each conference and enforces consistent structure,
+citation hygiene, and LaTeX formatting.
+
+---
+
+## Supported Venues
+
+| Track | Venues |
+|-------|--------|
+| ML/AI | NeurIPS, ICML, ICLR, AAAI, COLM |
+| NLP | ACL, EMNLP, NAACL |
+| Systems | OSDI, NSDI, ASPLOS, SOSP, EuroSys |
+
+---
+
+## Phase 1 — Understand the Contribution
+
+Before writing, extract the paper's core claim:
+
+1. **Read** the research repo: results, configs, README, notebooks.
+2. **Identify** the single sentence that captures the contribution.
+3. **List** 3–5 evidence points (tables, figures, ablations) that support it.
+4. **Determine** the target venue and load its formatting requirements (see Phase 5).
+
+Write a one-page outline to `paper/outline.md` before drafting.
+
+---
+
+## Phase 2 — Structure
+
+Standard ML paper structure (adapt per venue):
+
+```
+Abstract          — 150–250 words; problem, method, result, significance
+1. Introduction   — motivation, gap, contribution list, paper roadmap
+2. Related Work   — group by theme; distinguish from your approach
+3. Method         — notation, model, algorithm; self-contained
+4. Experiments    — datasets, baselines, metrics, main results, ablations
+5. Analysis       — error analysis, qualitative examples, limitations
+6. Conclusion     — summary, broader impact, future work
+References
+Appendix          — proofs, extended tables, reproducibility details
+```
+
+Systems papers swap Section 2–3 for Design + Implementation.
+
+---
+
+## Phase 3 — Writing Guidelines
+
+### Abstract
+- Sentence 1: the problem.
+- Sentence 2: why existing solutions fail.
+- Sentences 3–4: your approach in plain language.
+- Sentence 5: headline result with a number.
+- Sentence 6: significance / broader impact.
+
+### Introduction
+- Open with a concrete motivating example, not a generic statement.
+- State contributions as a bulleted list at the end.
+- Use present tense for your contributions; past tense for prior work.
+
+### Method
+- Define all notation in a table or dedicated paragraph before using it.
+- Every equation should be referenced in prose.
+- Include a system diagram or algorithm box.
+
+### Experiments
+- Lead with the main result table.
+- Bold the best result in each column.
+- Include error bars or confidence intervals.
+- Ablation table must isolate one variable per row.
+
+### Writing style
+- Active voice, short sentences, no hedging.
+- Avoid: "In this paper, we propose…" (say "We propose…").
+- Avoid: "very", "quite", "somewhat", "interesting".
+- Every claim needs a citation or evidence pointer.
+
+---
+
+## Phase 4 — Citation Hygiene
+
+1. Use BibTeX; never cite URLs directly in text.
+2. Verify each citation with `ss-arxiv-database` or WebSearch.
+3. Prefer arXiv IDs for preprints; use published venue entries when available.
+4. Run deduplication: `bibtool -s -d references.bib -o references_clean.bib`
+5. Check for missing venue/year fields before submission.
+
+---
+
+## Phase 5 — Venue-Specific Requirements
+
+### Loading Style Files
+```bash
+# NeurIPS
+wget https://neurips.cc/media/neurips-2024.sty
+
+# ICML
+wget https://icml.cc/media/icml2024.sty
+
+# ICLR — uses openreview template
+# ACL — use acl_latex.sty from aclpub
+```
+
+Or use WebFetch to retrieve the current year's author kit from the venue site.
+
+### Page Limits (verify for current year)
+| Venue | Main | + References | Appendix |
+|-------|------|-------------|---------|
+| NeurIPS | 9 | unlimited | unlimited |
+| ICML | 8 | unlimited | unlimited |
+| ICLR | 8 | unlimited | unlimited |
+| ACL | 8 | unlimited | unlimited |
+| OSDI/SOSP | 12 | included | — |
+
+### Reviewer Expectations by Venue
+- **NeurIPS/ICML/ICLR**: theory or strong empirical novelty; reproducibility checklist required.
+- **ACL**: linguistic motivation; include human evaluation for generation tasks.
+- **OSDI/SOSP/ASPLOS**: real system with eval on production-scale workloads; no toy benchmarks.
+
+---
+
+## Phase 6 — Camera-Ready Checklist
+
+- [ ] All author names, affiliations, and emails correct
+- [ ] Acknowledgments section includes grants and compute credits
+- [ ] All figures are vector (PDF/EPS) at ≥ 300 DPI
+- [ ] No `\TODO` or `\FIXME` macros remain
+- [ ] Bibliography sorted and deduplicated
+- [ ] Supplementary material compiles standalone
+- [ ] Reproducibility checklist completed (NeurIPS/ICML/ICLR)
+- [ ] PDF passes venue accessibility checker (NeurIPS requires it)
+- [ ] File size within venue limit (usually 50 MB)
+
+---
+
+## LaTeX Snippets
+
+### Algorithm block
+```latex
+\usepackage{algorithm, algpseudocode}
+
+\begin{algorithm}
+\caption{Your Algorithm}
+\begin{algorithmic}[1]
+  \Require input $x$
+  \State $y \gets f(x)$
+  \Return $y$
+\end{algorithmic}
+\end{algorithm}
+```
+
+### Table with bold best result
+```latex
+\begin{table}[t]
+\centering
+\caption{Main results on benchmark X.}
+\begin{tabular}{lcc}
+\toprule
+Method & Metric A & Metric B \\
+\midrule
+Baseline & 72.1 & 81.3 \\
+\textbf{Ours} & \textbf{78.4} & \textbf{85.7} \\
+\bottomrule
+\end{tabular}
+\end{table}
+```


### PR DESCRIPTION
Adds three new skills selected from the weekly discovery issue #15:
- ss-autoresearch: two-loop autonomous research orchestration
- ss-ml-paper-writing: publication-ready ML paper writing for top venues
- ss-mcp-builder: MCP server development guide (adapted from anthropics/skills)

Closes #15

Generated with [Claude Code](https://claude.ai/code)